### PR TITLE
Update CI + supported Ruby versions

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -9,8 +9,6 @@ Linux_task:
       - image: ruby:3.1-slim
       - image: ruby:3.2-slim
   install_script:
-    # git is installed since the gemspec uses it.
-    - apt-get update && apt-get install -y git
     - gem install bundler
     - bundle install
   script:

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -4,9 +4,10 @@ use_compute_credits: $CIRRUS_USER_COLLABORATOR == 'true' || $CIRRUS_BRANCH == 'm
 Linux_task:
   container:
     matrix:
-      - image: ruby:2.6-slim
       - image: ruby:2.7-slim
       - image: ruby:3.0-slim
+      - image: ruby:3.1-slim
+      - image: ruby:3.2-slim
   install_script:
     # git is installed since the gemspec uses it.
     - apt-get update && apt-get install -y git

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -4,7 +4,6 @@ use_compute_credits: $CIRRUS_USER_COLLABORATOR == 'true' || $CIRRUS_BRANCH == 'm
 Linux_task:
   container:
     matrix:
-      - image: ruby:2.7-slim
       - image: ruby:3.0-slim
       - image: ruby:3.1-slim
       - image: ruby:3.2-slim

--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,7 @@ source "https://rubygems.org"
 #
 # Ruby maintenance info: https://www.ruby-lang.org/en/downloads/branches/
 #
-# NOTE: Update how_is.gemspec when this is updated!
+# NOTE: Update okay.gemspec when this is updated!
 ruby ">= 3.0"
 
 # Specify your gem's dependencies in okay.gemspec

--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,7 @@ source "https://rubygems.org"
 # Ruby maintenance info: https://www.ruby-lang.org/en/downloads/branches/
 #
 # NOTE: Update how_is.gemspec when this is updated!
-ruby ">= 2.6"
+ruby ">= 2.7"
 
 # Specify your gem's dependencies in okay.gemspec
 gemspec

--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,7 @@ source "https://rubygems.org"
 # Ruby maintenance info: https://www.ruby-lang.org/en/downloads/branches/
 #
 # NOTE: Update how_is.gemspec when this is updated!
-ruby ">= 2.7"
+ruby ">= 3.0"
 
 # Specify your gem's dependencies in okay.gemspec
 gemspec

--- a/okay.gemspec
+++ b/okay.gemspec
@@ -16,9 +16,7 @@ Gem::Specification.new do |spec|
   spec.homepage      = "https://github.com/duckinator/okay"
   spec.license       = "MIT"
 
-  spec.files         = `git ls-files -z`.split("\x0").select do |f|
-    f.match(%r{^(README.md|LICENSE.txt|okay.gemspec|lib)})
-  end
+  spec.files         = ['README.md', 'LICENSE.txt', 'okay.gemspec'] + Dir['lib/**/*.rb']
   spec.bindir        = "exe"
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]

--- a/okay.gemspec
+++ b/okay.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |spec|
   # Ruby maintenance info: https://www.ruby-lang.org/en/downloads/branches/
   #
   # NOTE: Update Gemfile when this is updated!
-  spec.required_ruby_version = ">= 2.6"
+  spec.required_ruby_version = ">= 2.7"
 
   spec.add_runtime_dependency "cacert"
 

--- a/okay.gemspec
+++ b/okay.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |spec|
   # Ruby maintenance info: https://www.ruby-lang.org/en/downloads/branches/
   #
   # NOTE: Update Gemfile when this is updated!
-  spec.required_ruby_version = ">= 2.7"
+  spec.required_ruby_version = ">= 3.0"
 
   spec.add_runtime_dependency "cacert"
 


### PR DESCRIPTION
- Restrict Ruby version to 2.7+, since 2.6 and older has reached EOL.
- Update .cirrus.yml to include all supported Ruby versions and remove unsupported versions.
- Avoid having gemspec depend on the `git` executable.
- Update .cirrus.yml to not install `git`, since it's no longer needed.